### PR TITLE
Add export location of linux specific libraries to LUA_CPATH

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,7 +95,8 @@ jobs:
     - name: Check Build
       run: |
         ls example-project/dist/1.0.0
-        love12/love12.AppImage example-project/dist/1.0.0/ExampleGame.love
+        unzip example-project/dist/1.0.0/ExampleGame-linux.zip -d ExampleGame
+        ExampleGame/AppRun
     - name: Stop xvfb and openbox
       # should always stop xvfb and openbox even if other steps failed
       if: always()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,8 +95,9 @@ jobs:
     - name: Check Build
       run: |
         ls example-project/dist/1.0.0
-        unzip example-project/dist/1.0.0/ExampleGame-linux.zip -d ExampleGame
-        ExampleGame/AppRun
+        7z x example-project/dist/1.0.0/ExampleGame-linux.zip
+        ls example-project/dist/1.0.0
+        example-project/dist/1.0.0/ExampleGame/AppRun
     - name: Stop xvfb and openbox
       # should always stop xvfb and openbox even if other steps failed
       if: always()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,8 +102,7 @@ jobs:
     - name: Check Build
       run: |
         ls example-project/dist/1.0.0
-        7z x example-project/dist/1.0.0/ExampleGame-linux.zip
-        ls -a
+        7z x -y example-project/dist/1.0.0/ExampleGame-linux.zip
         ./AppRun
     - name: Stop xvfb and openbox
       # should always stop xvfb and openbox even if other steps failed

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -97,7 +97,7 @@ jobs:
         ls example-project/dist/1.0.0
         7z x example-project/dist/1.0.0/ExampleGame-linux.zip
         ls
-        ExampleGame-linux/AppRun
+        ./AppRun
     - name: Stop xvfb and openbox
       # should always stop xvfb and openbox even if other steps failed
       if: always()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -96,8 +96,8 @@ jobs:
       run: |
         ls example-project/dist/1.0.0
         7z x example-project/dist/1.0.0/ExampleGame-linux.zip
-        ls example-project/dist/1.0.0
-        example-project/dist/1.0.0/ExampleGame/AppRun
+        ls
+        ExampleGame-linux/AppRun
     - name: Stop xvfb and openbox
       # should always stop xvfb and openbox even if other steps failed
       if: always()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -96,7 +96,7 @@ jobs:
       run: |
         ls example-project/dist/1.0.0
         7z x example-project/dist/1.0.0/ExampleGame-linux.zip
-        ls
+        ls -a
         ./AppRun
     - name: Stop xvfb and openbox
       # should always stop xvfb and openbox even if other steps failed

--- a/love-build.lua
+++ b/love-build.lua
@@ -560,7 +560,7 @@ return {
     apprunfile = apprunfile .. 'if [ -z "$LUA_CPATH" ]; then\n'
     apprunfile = apprunfile .. '    LUA_CPATH=";"\n'
     apprunfile = apprunfile .. 'fi\n'
-    apprunfile = apprunfile .. 'export LUA_CPATH="$APPDIR/lib/lua/5.1/?.so;$LUA_CPATH"\n'
+    apprunfile = apprunfile .. 'export LUA_CPATH="$APPDIR/lib/?.so;$APPDIR/lib/lua/5.1/?.so;$LUA_CPATH"\n'
     apprunfile = apprunfile .. 'exec "$APPDIR/bin/' .. love.build.opts.name .. '" "$@"\n'
     local apprun = love.filesystem.openFile('temp/' .. srcdir .. '/squashfs-root/AppRun', 'w')
     apprun:write(apprunfile)

--- a/love-build.lua
+++ b/love-build.lua
@@ -538,6 +538,9 @@ return {
       local iconf = love.filesystem.openFile('temp/' .. srcdir .. '/squashfs-root/icon.png', 'w')
       iconf:write(i:_resize(img, 256):getString())
       iconf:close()
+      local icond = love.filesystem.openFile('temp/' .. srcdir .. '/squashfs-root/.DirIcon', 'w')
+      icond:write(i:_resize(img, 256):getString())
+      icond:close()
     end
     
     -- create AppRun file and move to temp/squashfs-root/AppRun

--- a/love-build.lua
+++ b/love-build.lua
@@ -538,9 +538,6 @@ return {
       local iconf = love.filesystem.openFile('temp/' .. srcdir .. '/squashfs-root/icon.png', 'w')
       iconf:write(i:_resize(img, 256):getString())
       iconf:close()
-      local icond = love.filesystem.openFile('temp/' .. srcdir .. '/squashfs-root/.DirIcon', 'w')
-      icond:write(i:_resize(img, 256):getString())
-      icond:close()
     end
     
     -- create AppRun file and move to temp/squashfs-root/AppRun


### PR DESCRIPTION
Thanks again for your huge patience and support.
This is the solution that works for me without having to add any extra code for the linux distribution inside the exported project itself.
I'm not sure if `$APPDIR/lib/lua/5.1/?.so` couldn't also get removed from LUA_CPATH as there never seems to be a `lua` directory within `lib` but I'm not familiar enough with lua distribution so I kept it.
I modified the linux workflow to use the `AppRun` generated by love-build in place of the love 12 appimage as the latter will find https for obvious reasons.
In the process I eliminated copying the `.DirIcon` as linux automatically generates one during the unzip process and you will always get an overwrite prompt which both disrupts the workflow and is actually a bit annoying for linux users trying to extract and it does not impact icon display.
I'm not sure what exactly causes it but the moment I unzip or compress into an .AppImage, a link to icon.png is created at `.DirIcon` so the compressed result always has the correct icon for me even without explicitly creating one in the build step. Alternatively we could only write it if the OS is not linux but ultimately this would be solved by love-build directly compressing into an AppImage.

Workflow run on my fork: https://github.com/Endaris/love-build/actions/runs/8853171216/job/24313412862