### PR TITLE
Flush build.log on LÖVE errors

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,14 @@
 -- load love.build 
 love.build = require('love-build')
 
+local errhand = love.errorhandler or love.errhand
+assert(errhand, "Unable to find default error handler!")
+function love.errorhandler(msg)
+  love.build.log((debug.traceback("Error: " .. tostring(msg), 4):gsub("\n[^\n]+$", "")))
+  love.build.dumpLogs()
+  return errhand(msg)
+end
+
 -- handle argument on start
 love.load = function(args)
   love.build.log('start')


### PR DESCRIPTION
Fixes #5

Result:

build.log:
```
start
starting build
setting up save directory
project mounted at: "D:\src\love/Plinko/game"

reading config
Error: love-build.lua:100: Syntax error: project/build.lua:21: '}' expected (to close '{' at line 2) near 'hooks'

stack traceback:
	love-build.lua:100: in function 'next'
	main.lua:64: in function 'update'
	[love "callbacks.lua"]:174: in function <[love "callbacks.lua"]:156>
	[C]: in function 'xpcall'
```

![image](https://github.com/ellraiser/love-build/assets/610685/fa85c627-4de1-4edd-9008-60520f0673f1)
